### PR TITLE
An image wrapped inside div does not display

### DIFF
--- a/image_inside_div_not_displaying
+++ b/image_inside_div_not_displaying
@@ -1,0 +1,4 @@
+<div id="my_photo">
+![Photo of Me](/images/bio-photo.JPG)
+</div>
+


### PR DESCRIPTION
An image wrapped inside a div does not show up in the html file created. The element #my_photo is styled as follows: 

#my_photo
{
  float: right;
  padding-left: 50px;
}